### PR TITLE
Add in-vim Jupyter terminal buffer automatic managment 

### DIFF
--- a/autoload/jupyter.vim
+++ b/autoload/jupyter.vim
@@ -150,21 +150,25 @@ endfunction
 
 function! jupyter#SendCell() abort 
     Pythonx jupyter_vim.run_cell()
+    call jupyter#RefreshTerminalBuf()
     call jupyter#ExecuteTerminal()
 endfunction
 
 function! jupyter#SendCode(code) abort 
     " NOTE: 'run_command' gives more checks than just raw 'send'
+    call jupyter#RefreshTerminalBuf()
     Pythonx jupyter_vim.run_command(vim.eval('a:code'))
     call jupyter#ExecuteTerminal()
 endfunction
 
 function! jupyter#SendRange() range abort 
+    call jupyter#RefreshTerminalBuf()
     execute a:firstline . ',' . a:lastline . 'Pythonx jupyter_vim.send_range()'
     call jupyter#ExecuteTerminal()
 endfunction
 
 function! jupyter#SendCount(count) abort 
+    call jupyter#RefreshTerminalBuf()
     " TODO move this function to pure(ish) python like SendRange
     let sel_save = &selection
     let cb_save = &clipboard

--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -82,6 +82,10 @@ def check_connection():
     """Check that we have a client connected to the kernel."""
     return kc.hb_channel.is_beating() if kc else False
 
+def UpdateVimTerminalStatus():
+    if not check_connection():
+        vim.command('let s:InitiazlizedJupyterWindow = 0')
+
 def warn_no_connection():
     vim_echom('WARNING: Not connected to Jupyter!' + \
                 '\nRun :JupyterConnect to find the kernel', style='WarningMsg')
@@ -350,7 +354,7 @@ def with_console(f):
     def wrapper(*args, **kwargs):
         if not check_connection():
             warn_no_connection()
-            return
+            return 
         monitor_console = bool(int(vim.vars.get('jupyter_monitor_console', 0)))
         f(*args, **kwargs)
         if monitor_console:


### PR DESCRIPTION
If there is no available session to connect to, the plugin opens a new terminal buffer that runs Jupyter console.

Features:
- Open a new terminal buffer if the connection to kernel fails.
- Send Enter key after execution for instant response, solves the problem of Jupyter console: 
> "in the console version jupyter console, the result will only show after you press the Enter key."
- No need to use JupyterConnect when working from vim

This feels like a more natural and simple approach that enables:
- Instant code execution without a running Jupyter kernel in the background.
- No need for external applications such as tmux.
- Potentially better communication between vim and Jupyter through vim commands.
- More "Matlab-like" feeling.

