### PR TITLE
Fix JupyterImportThisFile to PythonImportThisFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ By default, the following keybindings are defined:
 ```vim
 " Run current file
 nnoremap <buffer> <silent> <localleader>R :JupyterRunFile<CR>
-nnoremap <buffer> <silent> <localleader>I :JupyterImportThisFile<CR>
+nnoremap <buffer> <silent> <localleader>I :PythonImportThisFile<CR>
 
 " Change to directory of current file
 nnoremap <buffer> <silent> <localleader>d :JupyterCd %:p:h<CR>

--- a/doc/jupyter-vim.txt
+++ b/doc/jupyter-vim.txt
@@ -108,7 +108,7 @@ COMMANDS 					*jupyter-vim-commands*
 			interactive IPython environment:
 				:JupyterRunFile -i %:p
 
-:PythonImportThisFile 	      *jupyter-importthisfile* *:JupyterImportThisFile*
+:PythonImportThisFile 	      *jupyter-importthisfile* *:PythonImportThisFile*
                         Only makes sense to run when |b:jupyter_kernel_type| is
                         'python'.  Imports the current buffer as a python
                         module.  Essentially, this command runs
@@ -166,7 +166,7 @@ COMMANDS 					*jupyter-vim-commands*
 MAPPINGS					*jupyter-vim-mappings*
 
 <LocalLeader>R 		Run the current file (see |:JupyterRunFile|).
-<LocalLeader>I 		Import the current file (see |:JupyterImportThisFile|).
+<LocalLeader>I 		Import the current file (see |:PythonImportThisFile|).
 <localleader>d 		Change to the directory of the current file (see |:JupyterCd|).
 <localleader>X 		Execute the current cell (see |:JupyterSendCell|).
 <localleader>E 		Execute the current line (see |:JupyterSendRange|).

--- a/doc/jupyter-vim.txt
+++ b/doc/jupyter-vim.txt
@@ -335,5 +335,5 @@ I owe significant thanks to the original developer of this plugin: Paul Ivanov
 <https://github.com/wmvanvliet>. It is far easier to update something that
 already works well than to forge a new path from scratch.
 
-vim:tw=78:ts=8:noet:ft=text:norl:
+vim:tw=78:ts=8:noet:ft=help:norl:
 

--- a/ftplugin/python/jupyter.vim
+++ b/ftplugin/python/jupyter.vim
@@ -25,7 +25,7 @@ command! -nargs=0   PythonSetBreak  call jupyter#PythonDbstop()
 if exists('g:jupyter_mapkeys') && g:jupyter_mapkeys
 	" Run the current file
     nnoremap <buffer> <silent> <localleader>R :JupyterRunFile<CR>
-    nnoremap <buffer> <silent> <localleader>I :JupyterImportThisFile<CR>
+    nnoremap <buffer> <silent> <localleader>I :PythonImportThisFile<CR>
 
     " Change to directory of current file
     nnoremap <buffer> <silent> <localleader>d :JupyterCd %:p:h<CR>


### PR DESCRIPTION
Hi @wmvanvliet

Your plugin works great. I made a small check before putting it in my workflow.

__Problem__: `<leader>I` map not working
__Solution__: change the name of the command : `JupyterImportThisFile` to the new command `PythonImportThisFile`

Thank for your work.
