### PR TITLE
Feature: Allow choosing which kernel to connect to (response to issue #5)

### DIFF
--- a/autoload/jupyter.vim
+++ b/autoload/jupyter.vim
@@ -75,7 +75,7 @@ endfunction
 "-----------------------------------------------------------------------------
 function! jupyter#Connect(...) abort
     " call jupyter#init_python()
-    let l:kernel_file = a:0 > 0 ? a:1 : 'kernel-*.json'
+    let l:kernel_file = a:0 > 0 ? a:1 : '*.json'
     Pythonx jupyter_vim.connect_to_kernel(
                 \ jupyter_vim.vim2py_str(
                 \     vim.current.buffer.vars['jupyter_kernel_type']),

--- a/autoload/jupyter.vim
+++ b/autoload/jupyter.vim
@@ -73,11 +73,24 @@ endfunction
 "-----------------------------------------------------------------------------
 "        Vim -> Jupyter Public Functions:
 "-----------------------------------------------------------------------------
-function! jupyter#Connect() abort 
+function! jupyter#Connect(...) abort
     " call jupyter#init_python()
+    let l:kernel_file = a:0 > 0 ? a:1 : 'kernel-*.json'
     Pythonx jupyter_vim.connect_to_kernel(
                 \ jupyter_vim.vim2py_str(
-                \     vim.current.buffer.vars['jupyter_kernel_type']))
+                \     vim.current.buffer.vars['jupyter_kernel_type']),
+                \ filename=vim.eval('l:kernel_file'))
+endfunction
+
+function! jupyter#CompleteConnect(ArgLead, CmdLine, CursorPos) abort
+    " Pre-Declare variable <- setted from python
+    let l:kernel_ids = []
+    " Get kernel id from python
+    Pythonx jupyter_vim.find_jupyter_kernels()
+    " Filter id matching user arg
+    call filter(l:kernel_ids, '-1 != match(v:val, a:ArgLead)')
+    " Return list
+    return l:kernel_ids
 endfunction
 
 function! jupyter#Disconnect(...) abort
@@ -220,7 +233,8 @@ endfunction
 function! jupyter#MakeStandardCommands()
     " Standard commands, called from each ftplugin so that we only map the
     " keys buffer-local for select filetypes.
-    command! -buffer -nargs=0    JupyterConnect         call jupyter#Connect()
+    command! -buffer -nargs=* -complete=customlist,jupyter#CompleteConnect
+          \ JupyterConnect call jupyter#Connect(<f-args>)
     command! -buffer -nargs=0    JupyterDisconnect      call jupyter#Disconnect()
     command! -buffer -nargs=1    JupyterSendCode        call jupyter#SendCode(<args>)
     command! -buffer -count      JupyterSendCount       call jupyter#SendCount(<count>)

--- a/autoload/jupyter.vim
+++ b/autoload/jupyter.vim
@@ -80,7 +80,11 @@ function! jupyter#Connect() abort
                 \     vim.current.buffer.vars['jupyter_kernel_type']))
 endfunction
 
-function! jupyter#JupyterCd(...) abort
+function! jupyter#Disconnect(...) abort
+    Pythonx jupyter_vim.disconnect_from_kernel()
+endfunction
+
+function! jupyter#JupyterCd(...) abort 
     " Behaves just like typical `cd`.
     let l:dirname = a:0 ? a:1 : ''
     if b:jupyter_kernel_type == 'python'
@@ -217,6 +221,7 @@ function! jupyter#MakeStandardCommands()
     " Standard commands, called from each ftplugin so that we only map the
     " keys buffer-local for select filetypes.
     command! -buffer -nargs=0    JupyterConnect         call jupyter#Connect()
+    command! -buffer -nargs=0    JupyterDisconnect      call jupyter#Disconnect()
     command! -buffer -nargs=1    JupyterSendCode        call jupyter#SendCode(<args>)
     command! -buffer -count      JupyterSendCount       call jupyter#SendCount(<count>)
     command! -buffer -range -bar JupyterSendRange       <line1>,<line2>call jupyter#SendRange()

--- a/doc/jupyter-vim.txt
+++ b/doc/jupyter-vim.txt
@@ -65,7 +65,7 @@ work in progress).
 --------------------------------------------------------------------------------
 COMMANDS 					*jupyter-vim-commands*
 
-:JupyterConnect 			    *jupyter-connect* *:JupyterConnect*
+:JupyterConnect [connection_file]	    *jupyter-connect* *:JupyterConnect*
 			Connect to an existing `jupyter kernel`. Kernel may be
 			any type (not just IPython). Connection attempt will
 			timeout after five seconds, and give a warning. Other
@@ -75,6 +75,11 @@ COMMANDS 					*jupyter-vim-commands*
                         This command assumes the language of the Jupyter kernel
                         is |b:jupyter_kernel_type|; errors may occur if the
                         kernel type is incorrect.
+
+			An optional [connection_file] can be given. It must
+			match the name or the id of the kernel connection
+			file given by `ipython kernel -f connection_file`,
+			by default it looks like `kernel-13423.json`.
 
 			Note that a `jupyter console` need not be running to
 			connect to a `jupyter kernel`, but the console is

--- a/plugin/jupyter.vim
+++ b/plugin/jupyter.vim
@@ -19,6 +19,7 @@ endif
 "        Configuration: {{{
 "-----------------------------------------------------------------------------
 let s:default_settings = {
+    \ 'shortmess': 0,
     \ 'auto_connect': 0,
     \ 'mapkeys': 1,
     \ 'monitor_console': 0,

--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -197,8 +197,8 @@ def connect_to_kernel(kernel_type):
         try:
             cfile = find_connection_file()  # default filename='kernel-*.json'
         except IOError:
-            vim_echom("kernel connection attempt {:d} failed - no kernel file"\
-                      .format(attempt), style="Error")
+            vim_echom("kernel connection attempt {:d}/{:d} failed - no kernel file"\
+                      .format(attempt, max_attempts), style="Error")
             continue
 
         # Create the kernel manager and connect a client
@@ -231,7 +231,7 @@ def connect_to_kernel(kernel_type):
         vim_echom('kernel connection successful! pid = {}'.format(pid),
                   style='Question')
     else:
-        kc.stop_channels()
+        if None is not kc: kc.stop_channels()
         vim_echom('kernel connection attempt timed out', style='Error')
 
 def disconnect_from_kernel():

--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -263,7 +263,7 @@ def connect_to_kernel(kernel_type, filename='kernel-*.json'):
 def disconnect_from_kernel():
     """Disconnect kernel client."""
     if None is not kc: kc.stop_channels()
-    vim_echom("Client disconnected from kernel with pid = {}".format(pid))
+    vim_echom("Disconnected: {}".format(cfile), style='Directory')
 
 def update_console_msgs():
     """Grab pending messages and place them inside the vim console monitor."""

--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -242,8 +242,12 @@ def find_jupyter_kernels():
 
     # Get all kernel json files
     jupyter_path = jupyter_runtime_dir()
-    runtime_files = [f for f in os.listdir(jupyter_path)
-                     if os.path.isfile(os.path.join(jupyter_path, f))]
+    runtime_files = []
+    for file_path in os.listdir(jupyter_path):
+        full_path = os.path.join(jupyter_path, file_path)
+        file_ext = os.path.splitext(file_path)[1]
+        if (os.path.isfile(full_path) and '.json' == file_ext):
+            runtime_files.append(file_path)
 
     # Get all the kernel ids
     kernel_ids = []
@@ -257,7 +261,7 @@ def find_jupyter_kernels():
 #------------------------------------------------------------------------------
 #        Major Function Definitions:
 #------------------------------------------------------------------------------
-def connect_to_kernel(kernel_type, filename='kernel-*.json'):
+def connect_to_kernel(kernel_type, filename=''):
     """Create kernel manager from existing connection file."""
     from jupyter_client import KernelManager, find_connection_file
 

--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -262,7 +262,7 @@ def connect_to_kernel(kernel_type, filename='kernel-*.json'):
 
 def disconnect_from_kernel():
     """Disconnect kernel client."""
-    kc.stop_channels()
+    if None is not kc: kc.stop_channels()
     vim_echom("Client disconnected from kernel with pid = {}".format(pid))
 
 def update_console_msgs():


### PR DESCRIPTION
Hi @wmvanvliet,

As you can see, I have free time. So I added the feature asked by issue #5 to choose the kernel image.
Also, I resuscitate `:JupyterDisconnect` command : it got loose I guess.

Ok I tell you: the secret was to parse `jupyter_core.paths.jupyter_runtime_dir()` to give the id (in my case) or filename or regex to `find_connection_file(filename="23087")`.

![jupyter_vim_choose_kernel](https://user-images.githubusercontent.com/6123962/70677932-574f8c00-1c6f-11ea-9b19-a3154369ea56.gif)
