### PR TITLE
Allow indented code cells

### DIFF
--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -225,7 +225,7 @@ def is_cell_separator(line):
     """ Determine whether a given line is a cell separator """
     # TODO allow users to define their own cell separators
     cell_sep = ('##', '#%%', '# %%', '# <codecell>')
-    return line.startswith(cell_sep)
+    return line.strip().startswith(cell_sep)
 
 # from <http://serverfault.com/questions/71285/\
 # in-centos-4-4-how-can-i-strip-escape-sequences-from-a-text-file>


### PR DESCRIPTION
This change allows indented code cells by stripping the line before
looking for the marker. This is the same behavior as found the Spyder
editor and makes it possible to step through parts of code in for
instance a "__main__" block:

    # %%
    if __name__ == "__main__":
        print("Main starts")
        # %%
        print("Main continues")
        # %%
        print("Main ends")