### PR TITLE
Jupyter Magic Commands

### DIFF
--- a/autoload/jupyter.vim
+++ b/autoload/jupyter.vim
@@ -223,6 +223,53 @@ function! s:opfunc(type)
 endfunction
 
 "-----------------------------------------------------------------------------
+"        Magic Functions:
+"-----------------------------------------------------------------------------
+function! jupyter#Clear()
+    " Allow Matplotlib inline
+    JupyterSendCode 'clear'
+	call jupyter#NewLine()
+endfunction
+
+function! jupyter#MatplotInline()
+    " Allow Matplotlib inline
+    JupyterSendCode '%matplotlib inline'
+endfunction
+
+function! jupyter#NewLine()
+    " Send a new line [needs to be used after jupyter#Clear()]
+    JupyterSendCode ' '
+endfunction
+
+function! jupyter#Reset()
+    " Force a reset
+    JupyterSendCode '%reset -f'
+endfunction
+
+function! jupyter#SendVariable()
+    " Print the variable that is on the current line
+	normal! 0"0yiw
+	let variable_send = @0
+    JupyterSendCode ''.escape(variable_send, '"').''
+endfunction
+
+function! jupyter#Whos()
+    " Prints all interactive variables
+    JupyterSendCode '%whos'
+endfunction
+
+function! jupyter#MakeMagicCommands()
+    " Below variable needs to be set if you want to use it
+	" let g:jupyter_magic = 1
+    command! -buffer -nargs=0    JupyterClear           call jupyter#Clear()
+    command! -buffer -nargs=0    JupyterMatplot         call jupyter#MatplotInline()
+    command! -buffer -nargs=0    JupyterNewLine         call jupyter#NewLine()
+    command! -buffer -nargs=0    JupyterReset           call jupyter#Reset()
+    command! -buffer -nargs=0    JupyterSendVariable    call jupyter#SendVariable()
+    command! -buffer -nargs=0    JupyterWhos            call jupyter#Whos()
+endfunction
+
+"-----------------------------------------------------------------------------
 "        Auxiliary Functions:
 "-----------------------------------------------------------------------------
 function! jupyter#PythonDbstop()

--- a/plugin/jupyter.vim
+++ b/plugin/jupyter.vim
@@ -47,6 +47,10 @@ augroup JupyterVimInit
     autocmd FileType julia,python if g:jupyter_mapkeys |
                 \ call jupyter#MapStandardKeys() |
                 \ endif
+
+    autocmd FileType julia,python if g:jupyter_magic |
+                \ call jupyter#MakeMagicCommands() |
+                \ endif
 augroup END
 
 "}}}----------------------------------------------------------------------------


### PR DESCRIPTION
Added a host of Jupyter Magic commands (but not mapped), add this to your .vimrc or init.vim to add the commands

```
let g:jupyter_magic = 1
```

##  Description of Added Functions

#### 1. JupyterClear
Sends `clear` to clear the screen (also fixed the issue present in #38)

#### 2. JupyterMatplot
Sends `%matplotlib inline` to allow inline matplotlib plots in Qtconsole

#### 3. JupyterNewLine
Sends a simple carriage return. It's needed for **JupyterClear** and it helps to "scroll" if needed.

#### 4. JupyterReset
Sends `%reset -f`, which does a hard reset on the session. Erasing everything

#### 5. JupyterSendVariable
Prints the variable that you are currently on. 
Example:
```
# Vim Code
x = 10*100 # ==> You are currently here in vim code
y = 2*x
```

```
# Jupyter console
[remote] In[26]: x
[remote] Out[26]: 1000
```

#### 6. JupyterWhos
Sends `%whos`, prints all interactive variables







