### PR TITLE
Fix: g:jupyter_cell_separators (Issue #60)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,4 @@ before_script: |
   git clone https://github.com/junegunn/vader.vim.git
 
 script: |
-  vim -Nu <(cat << VIMRC
-  filetype off
-  set rtp+=vader.vim
-  set rtp+=.
-  set rtp+=after
-  filetype plugin indent on
-  syntax enable
-  VIMRC) -c 'Vader! test/*' > /dev/null
+  vim -Nu ./test/vimrc -c 'Vader! test/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,44 +4,33 @@
 
 language: generic
 python: 3.7
+
+
 cache:
+  # Enable cache folder
+  bundler: true
   directories:
-    - $HOME/.rvm
-    - $HOME/.vvm
+    - $HOME/docker_images
+
+before_cache:
+  # Save tagged docker images. Info at https://github.com/travis-ci/travis-ci/issues/5358#issuecomment-248915326
+  - >
+    mkdir -p $HOME/docker_images && docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}'
+    | xargs -n 2 -t sh -c 'test -e $HOME/docker_images/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker_images/$1.tar.gz'
 
 before_install:
-  # Remove travis junk (2013)
-  - sudo apt-get remove --purge vim vim-runtime vim-gnome vim-tiny vim-gui-common
-  - sudo rm -rf /usr/local/share/vim /usr/bin/vim
-  # Update
-  - sudo add-apt-repository ppa:deadsnakes/ppa -y
-  - sudo apt-get update -y
-  - sudo apt-get install python3.7-dev
-  # Install Pip
-  - sudo apt-get install -y python3-setuptools
-  - sudo apt-get install -y python3-pip
-  # Install Jupyter
-  - python3.7 -m pip install wheel
-  - python3.7 -m pip install jupyter
-  - python3.7 -m pip install jupyter-console
-  # Install Vim
-  - git clone --depth 1 https://github.com/vim/vim
-  - cd vim
-  - export PATH=/usr/bin:$PATH
-  - ./configure $C_OPTS
-            --with-features=huge
-            --prefix=/usr/local
-            --enable-python3interp=dynamic
-            --with-python3-command=python3.7
-            --with-python3-config-dir=$(python3.7-config --configdir)
-            --with-compiledby="JupyterVim"
-  - make
-  - sudo make install
-  - cd -
-  - pwd
+  # Install docker
+  - n_image=$(ls -1 $HOME/docker_images/*.tar.gz | wc -l)
+  - if (( $n_image )); then ls $HOME/docker_images/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load";
+    else docker build --tag jupyter-vim .;
+    fi
 
-before_script: |
-  git clone https://github.com/junegunn/vader.vim.git
+env:
+  - VIM_VERSION=vint
+  - VIM_VERSION=pylint
+
 
 script: |
-  vim -Nu ./test/vimrc -c 'Vader! test/*'
+  - if [[ "$VIM_VERSION" == vint ]]; then vint -s . && vint -s test/vimrc;
+    elif [[ "$VIM_VERSION" == pylint ]]; then shopt -s extglob; pylint  **/*.py;
+    else docker run -a stderr -e "VADER_OUTPUT_FILE=/dev/stderr" vim -Nu ./test/vimrc -c 'Vader! test/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 #   vim latest
 
 language: generic
-python: 3.7
 
 
 cache:
@@ -28,9 +27,11 @@ before_install:
 env:
   - VIM_VERSION=vint
   - VIM_VERSION=pylint
+  - VIM_VERSION=vim_8.1.0519
 
 
 script: |
   - if [[ "$VIM_VERSION" == vint ]]; then vint -s . && vint -s test/vimrc;
     elif [[ "$VIM_VERSION" == pylint ]]; then shopt -s extglob; pylint  **/*.py;
-    else docker run -a stderr -e "VADER_OUTPUT_FILE=/dev/stderr" vim -Nu ./test/vimrc -c 'Vader! test/*'
+    docker run -it --rm -v $PWD/:/testplugin jupyter-vim "/vim-build/bin/$VIM_VERSION" -i NONE -N -u /testplugin/test/vimrc -Es '+Vader! /testplugin/test/*.vader'
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
 script:
   - run_docker=(docker run -it --rm -v $PWD/:/testplugin jupyter-vim)
   - if [[ "$VIM_VERSION" == vint ]]; then "${run_docker[@]}" bash -c "vint -s /testplugin && vint -s /testplugin/test/vimrc";
-    elif [[ "$VIM_VERSION" == pylint ]]; then "${run_docker[@]}" bash -c "shopt -s extglob; pylint /testplugin/**/*.py";
-    else "${run_docker[@]}" jupyter-vim "/vim-build/bin/$VIM_VERSION" -i NONE -N -u /testplugin/test/vimrc -Es '+Vader! /testplugin/test/*.vader';
+    elif [[ "$VIM_VERSION" == pylint ]]; then "${run_docker[@]}" bash -c "shopt -s extglob; pylint --disable=E0401,W0511 /testplugin/**/*.py";
+    else "${run_docker[@]}" "/vim-build/bin/$VIM_VERSION" -i NONE -N -u /testplugin/test/vimrc -Es '+Vader! /testplugin/test/*.vader';
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,10 @@ env:
   - VIM_VERSION=vim_8.1.0519
 
 
-script: |
-  - if [[ "$VIM_VERSION" == vint ]]; then vint -s . && vint -s test/vimrc;
-    elif [[ "$VIM_VERSION" == pylint ]]; then shopt -s extglob; pylint  **/*.py;
-    docker run -it --rm -v $PWD/:/testplugin jupyter-vim "/vim-build/bin/$VIM_VERSION" -i NONE -N -u /testplugin/test/vimrc -Es '+Vader! /testplugin/test/*.vader'
+script:
+  - run_docker=(docker run -it --rm -v $PWD/:/testplugin jupyter-vim)
+  - if [[ "$VIM_VERSION" == vint ]]; then "${run_docker[@]}" bash -c "vint -s /testplugin && vint -s /testplugin/test/vimrc";
+    elif [[ "$VIM_VERSION" == pylint ]]; then "${run_docker[@]}" bash -c "shopt -s extglob; pylint /testplugin/**/*.py";
+    else "${run_docker[@]}" jupyter-vim "/vim-build/bin/$VIM_VERSION" -i NONE -N -u /testplugin/test/vimrc -Es '+Vader! /testplugin/test/*.vader';
+    fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM testbed/vim:latest
+
+# Add packages
+RUN apk --no-cache update
+RUN apk --no-cache --update add gcc build-base autoconf coreutils
+RUN apk --no-cache --update add libffi-dev libzmq libzmq zeromq-dev zeromq freetype libpng libjpeg-turbo freetype-dev libpng-dev libjpeg-turbo-dev
+RUN apk --no-cache --update add bash git
+RUN apk --no-cache --update add python3 py3-pip python3-dev
+
+## Get vint for linting
+RUN pip3 install vim-vint
+RUN pip3 install pylint
+RUN pip3 install wheel
+RUN pip3 install pyzmq
+RUN pip3 install jupyter
+RUN pip3 install jupyter-console
+
+# Get vader for unit tests
+RUN git clone -n https://github.com/junegunn/vader.vim /vader
+WORKDIR /vader
+RUN git checkout de8a976f1eae2c2b680604205c3e8b5c8882493c
+
+# Build vim and neovim versions we want to test
+WORKDIR /
+# for cache deletion
+RUN install_vim -tag v8.0.0027 -py -py3 -name vim_8.0.0027 -build \
+                -tag v8.1.0519 -py -py3 -name vim_8.1.0519 -build \
+                -tag neovim:v0.3.8 -py -py3 -name nvim_0.3.8 -build

--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ nnoremap <buffer> <silent> <localleader>b :PythonSetBreak<CR>
 
 Set `let g:jupyter_mapkeys = 0` in your `.vimrc` to prevent the default keybindings from being made.
 
+## Related plugin
+
+* [vim-repl](https://github.com/sillybun/vim-repl): Instead of connecting to, embed the REPL in vim
+* [vimpyter](https://github.com/szymonmaszke/vimpyter): Integration with jupyter, even the notebook
+* [vim-ipython-cell](https://github.com/hanschen/vim-ipython-cell): send cell to jupyter via slime, requires terminal multiplexing instead of zeromq to communicate (higer level)
+* [jupytext.vim](https://github.com/goerz/jupytext.vim): Convert notebook files to vim buffers
+
+
 ## Info
 
 Once we fell in love with Vim, we couldn't bear having to jump back and forth

--- a/autoload/jupyter.vim
+++ b/autoload/jupyter.vim
@@ -122,7 +122,7 @@ endfunction
 
 function! jupyter#JupyterCd(...) abort 
     " Behaves just like typical `cd`.
-    let l:dirname = a:0 ? a:1 : "$HOME"
+    let l:dirname = a:0 ? a:1 : '$HOME'
     " Helpers:
     " " . -> vim cwd
     if l:dirname ==# '.' | let l:dirname = getcwd() | endif

--- a/autoload/jupyter/load.vim
+++ b/autoload/jupyter/load.vim
@@ -75,6 +75,6 @@ endfunction
 
 
 " Operator function to run selected|operator text
-function! s:opfunc_run_code(type)
+function! s:opfunc_run_code(type) abort
     call s:get_opfunc(function('jupyter#SendCode'))(a:type)
 endfunction

--- a/doc/jupyter-vim.txt
+++ b/doc/jupyter-vim.txt
@@ -375,6 +375,7 @@ $ jupyter qtconsole --version # 4.3.1
 CHANGELOG					*jupyter-vim-changelog*
 
 [v0.0?]
+* Feature: Do not ignore Indented when using JupyterSendCell (Issue #47)
 * Restore support for custom cell with g:jupyter_cell_separators
 * Refactor command names `:J*` -> `:Jupyter*`. Retrocompatibility.
 * Refactor command names `:Jupyter*` -> `:J*`. Nobody likes typing.

--- a/doc/jupyter-vim.txt
+++ b/doc/jupyter-vim.txt
@@ -375,6 +375,7 @@ $ jupyter qtconsole --version # 4.3.1
 CHANGELOG					*jupyter-vim-changelog*
 
 [v0.0?]
+* Restore support for custom cell with g:jupyter_cell_separators
 * Refactor command names `:J*` -> `:Jupyter*`. Retrocompatibility.
 * Refactor command names `:Jupyter*` -> `:J*`. Nobody likes typing.
 * Add `b:jupyter_exec_before` and its 3 brothers

--- a/plugin/jupyter.vim
+++ b/plugin/jupyter.vim
@@ -15,18 +15,19 @@ endif
 "-----------------------------------------------------------------------------
 "        Configuration: {{{
 "-----------------------------------------------------------------------------
-let s:default_settings = {
+let g:jupyter_default_settings = {
     \ 'auto_connect': 0,
-    \ 'cell_separators': "['##', '#%%', '# %%', '# <codecell>']",
+    \ 'cell_separators': ['##', '#%%', '# %%', '# <codecell>'],
     \ 'mapkeys': 1,
     \ 'monitor_console': 0,
-    \ 'timer_intervals': '[300, 600, 1000, 1500, 3000, 10000]',
+    \ 'timer_intervals': [300, 600, 1000, 1500, 3000, 10000],
     \ 'verbose': 0
 \ }
 
-for [s:key, s:val] in items(s:default_settings)
+for [s:key, s:val] in items(g:jupyter_default_settings)
     if !exists('g:jupyter_' . s:key)
-        execute 'let g:jupyter_' . s:key . ' = ' . s:val
+        let value = s:val
+        execute 'let g:jupyter_' . s:key . ' = value'
     endif
 endfor
 

--- a/pythonx/jupyter_util.py
+++ b/pythonx/jupyter_util.py
@@ -100,6 +100,7 @@ def str_to_vim(obj):
     str
         Double-quoted string.
     """
+    # pylint: disable=undefined-variable  # unicode
     # Encode
     is_py3 = version_info[0] >= 3
     if is_py3:
@@ -107,7 +108,6 @@ def str_to_vim(obj):
             obj = obj.encode()
         obj = str(obj, 'utf-8')
     else:
-        # pylint: disable=undefined-variable
         obj = unicode(obj, 'utf-8')  # noqa: E0602
 
     # Vim cannot deal with zero bytes:

--- a/pythonx/jupyter_util.py
+++ b/pythonx/jupyter_util.py
@@ -12,12 +12,12 @@ from jupyter_core.paths import jupyter_runtime_dir
 import vim
 
 
-def is_integer(s):
+def is_integer(s_in):
     """Check if string represents an integer."""
-    s = str(s)
-    if s[0] in ('-', '+'):
-        return s[1:].isdigit()
-    return s.isdigit()
+    s_in = str(s_in)
+    if s_in[0] in ('-', '+'):
+        return s_in[1:].isdigit()
+    return s_in.isdigit()
 
 
 def echom(arg, style='None'):
@@ -120,21 +120,21 @@ def str_to_vim(obj):
     return f'"{obj:s}"'
 
 
-def unquote_string(s):
+def unquote_string(s_in):
     """Remove single and double quotes from beginning and end of `s`."""
-    if isinstance(s, bytes):
-        s = s.decode()
-    if not isinstance(s, str):
-        s = str(s)
+    if isinstance(s_in, bytes):
+        s_in = s_in.decode()
+    if not isinstance(s_in, str):
+        s_in = str(s_in)
     for quote in ("'", '"'):
-        s = s.rstrip(quote).lstrip(quote)
-    return s
+        s_in = s_in.rstrip(quote).lstrip(quote)
+    return s_in
 
 
-def strip_color_escapes(s):
+def strip_color_escapes(s_in):
     """Remove ANSI color escape sequences from a string."""
     re_strip_ansi = re.compile(r'\x1B\[([0-9]{1,2}(;[0-9]{1,2})*)?[mK]')
-    return re_strip_ansi.sub('', s)
+    return re_strip_ansi.sub('', s_in)
 
 
 def prettify_execute_intput(line_number, cmd, prompt_in):
@@ -173,8 +173,8 @@ def match_kernel_id(fpath):
     str
         Kernel id as a string.
     """
-    m = re.search(r'kernel-(.+)\.json', str(fpath))
-    return m[1] if m else None
+    m_kernel = re.search(r'kernel-(.+)\.json', str(fpath))
+    return m_kernel[1] if m_kernel else None
 
 
 def find_jupyter_kernel_ids():

--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -266,11 +266,11 @@ class JupyterVimSession():
             self.vim_client.thread_echom('kernel connection attempt timed out', style='Error')
             return
 
-        # Pre-message the user
-        self.vim_client.thread_echom('Connected! ', style='Question')
-
         # Collect and echom kernel info
         self.vim_client.thread_echom_kernel_info(self.kernel_client.get_kernel_info(self.lang))
+
+        # Inform everything ok, at last
+        self.vim_client.thread_echom('Connected! ', style='Question')
 
         # TODO only if verbose
         # Print vim connected -> client

--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -33,14 +33,15 @@ Install:
 try:
     # pylint: disable=unused-import
     import jupyter   # noqa
-except ImportError as e:
+except ImportError as e_import:
     raise ImportError("Could not import jupyter.\n(The original ImportError: {})\n{}"
-                      .format(e, __doc__)) from e
+                      .format(e_import, __doc__)) from e_import
 
 try:
     import vim
-except ImportError as e:
-    raise ImportError('vim module only available within vim! The original ImportError: ' + str(e)) from e
+except ImportError as e_import:
+    raise ImportError('vim module only available within vim! The original ImportError: ' \
+            + str(e_import)) from e_import
 
 # Standard
 import functools
@@ -154,8 +155,8 @@ class JupyterVimSession():
         if isinstance(sig, str):
             try:
                 sig = getattr(signal, sig)
-            except Exception as e:
-                echom(f"Cannot send signal {sig} on this OS: {e}", style='Error')
+            except (AttributeError, NameError) as err:
+                echom(f"Cannot send signal {sig} on this OS: {err}", style='Error')
                 return
 
         # Clause: valid pid
@@ -237,8 +238,8 @@ class JupyterVimSession():
         connected = self.kernel_client.check_connection()
 
         # Try to connect
-        MAX_ATTEMPTS = 3
-        for attempt in range(MAX_ATTEMPTS):
+        max_attempts = 3
+        for attempt in range(max_attempts):
             # NOTE if user tries to :JupyterConnect <new_pid>, this check will ignore
             # the requested new pid.
             if connected:
@@ -254,7 +255,7 @@ class JupyterVimSession():
             except IOError:
                 self.vim_client.thread_echom(
                     "kernel connection attempt {:d}/{:d} failed - no kernel file"
-                    .format(attempt, MAX_ATTEMPTS), style="Error")
+                    .format(attempt, max_attempts), style="Error")
                 continue
 
             # Connect
@@ -305,6 +306,7 @@ class JupyterVimSession():
             cwd = self.kernel_client.send_code_and_get_reply(self.lang.cwd)
             echom('CWD: ', style='Question')
             vim.command("echon \"{}\"".format(cwd))
+        # pylint: disable=broad-except  # Catching too general exception Exception
         except Exception:
             pass
 

--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -35,12 +35,12 @@ try:
     import jupyter   # noqa
 except ImportError as e:
     raise ImportError("Could not import jupyter.\n(The original ImportError: {})\n{}"
-                      .format(e, __doc__))
+                      .format(e, __doc__)) from e
 
 try:
     import vim
 except ImportError as e:
-    raise ImportError('vim module only available within vim! The original ImportError: ' + str(e))
+    raise ImportError('vim module only available within vim! The original ImportError: ' + str(e)) from e
 
 # Standard
 import functools

--- a/pythonx/language.py
+++ b/pythonx/language.py
@@ -5,13 +5,14 @@ To add a language, please fill all the field.
 If it is hard, just put '-1', it will never complain.
 See cpp's way to run a file (defer work to python)
 """
+# pylint: disable=too-few-public-methods
 
 # Export only: see at end
 __all__ = ['list_languages', 'get_language']
 
 
 class Language:
-    """Language Base"""
+    """ Language Base """
     prompt_in = 'In [{:d}]: '
     prompt_out = 'Out[{:d}]: '
     print_string = 'print("{}")'
@@ -23,7 +24,7 @@ class Language:
 
 
 class Bash(Language):
-    """Bourne Again Shell"""
+    """ Bourne Again Shell """
     prompt_in = 'Sh [{:d}]: '
     print_string = 'echo -e "{}"'
     run_file = 'source "{}"'
@@ -34,7 +35,7 @@ class Bash(Language):
 
 
 class Cpp(Language):
-    """Note :Pid is the first to run, so make import there
+    """ Note :Pid is the first to run, so make import there
     I don't want to implement include so let it to -1,
         then python send file content
     """
@@ -57,7 +58,7 @@ class Cpp(Language):
 
 
 class Java(Language):
-    """Java: compiled for jvm"""
+    """ Java: compiled for jvm """
     prompt_in = 'Ja [{:d}]: '
     print_string = 'System.out.println("{}");'
     run_file = """ // Import
@@ -85,7 +86,7 @@ class Java(Language):
 
 
 class Javascript(Language):
-    """Js script excutable with nodejs"""
+    """ Js script excutable with nodejs """
     prompt_in = 'Js [{:d}]: '
     print_string = 'console.log("{}");'
     run_file = 'eval("" + require("fs").readFileSync("{}"));'
@@ -96,7 +97,7 @@ class Javascript(Language):
 
 
 class Julia(Language):
-    """Julia: interpreted dynamic programming"""
+    """ Julia: interpreted dynamic programming """
     prompt_in = 'Jl [{:d}]: '
     print_string = 'println("{}")'
     run_file = 'include("{}")'
@@ -107,7 +108,7 @@ class Julia(Language):
 
 
 class Perl(Language):
-    """Perl: script"""
+    """ Perl: script """
     prompt_in = 'Pl [{:d}]: '
     print_string = 'print("{}")'
     run_file = 'my $_res = "{}"; $_res =~ s/\\.[^.]+$//; do $_res;'
@@ -118,7 +119,7 @@ class Perl(Language):
 
 
 class Python(Language):
-    """Python: script"""
+    """ Python: script """
     prompt_in = 'Py [{:d}]: '
     print_string = 'print("{}")'
     run_file = '%run "{}"'
@@ -128,8 +129,9 @@ class Python(Language):
     hostname = 'import socket; _res = socket.gethostname()'
 
 
+# pylint: disable=C0103  # Class name "R" no PascalCase naming style
 class R(Language):
-    """R: script"""
+    """ R: script """
     prompt_in = 'R [{:d}]: '
     print_string = 'print("{}")'
     run_file = 'source("{}")'
@@ -140,7 +142,7 @@ class R(Language):
 
 
 class Raku(Language):
-    """Raku: script (used to be Perl6)"""
+    """ Raku: script (used to be Perl6) """
     prompt_in = 'Ra [{:d}]: '
     print_string = 'say("{}");'
     run_file = '#% run {}'
@@ -151,7 +153,7 @@ class Raku(Language):
 
 
 class Ruby(Language):
-    """Ruby: script"""
+    """ Ruby: script """
     prompt_in = 'Rb [{:d}]: '
     print_string = 'print("{}")'
     run_file = 'load "{}"'
@@ -162,7 +164,7 @@ class Ruby(Language):
 
 
 class Rust(Language):
-    """Rust: compiled, strongly typed"""
+    """ Rust: compiled, strongly typed """
     prompt_in = 'Rs [{:d}]: '
     print_string = 'println!("{}");'
     run_file = '-1'
@@ -205,12 +207,12 @@ language_dict = {
 
 
 def list_languages():
-    """List coding languages implemented by module"""
+    """ List coding languages implemented by module """
     return language_dict.keys()
 
 
 def get_language(kernel_type):
-    """Get language class
+    """ Get language class
     Assert that language is in language_list (checked by caller)
     But still, let's return something
     """

--- a/pythonx/message_parser.py
+++ b/pythonx/message_parser.py
@@ -96,8 +96,10 @@ class VimMessenger():
 
     def is_cell_separator(self, line):
         """Return True if given `line` is a cell separator."""
-        return any([bool(re.match(separation, line.strip()))
-                    for separation in self.cell_separators])
+        for separation in self.cell_separators:
+            if re.match(separation, line.strip()):
+                return True
+        return False
 
     def thread_echom(self, arg, **args):
         """Wrap echo async: put message to be echoed in a queue."""

--- a/pythonx/message_parser.py
+++ b/pythonx/message_parser.py
@@ -97,7 +97,7 @@ class VimMessenger():
     def is_cell_separator(self, line):
         """Return True if given `line` is a cell separator."""
         for separation in self.cell_separators:
-            if re.match(separation, line.strip()):
+            if re.match(separation, line):
                 return True
         return False
 

--- a/pythonx/message_parser.py
+++ b/pythonx/message_parser.py
@@ -12,18 +12,16 @@ from time import sleep
 
 # Py module
 from jupyter_client import KernelManager
-import vim
-
 # Local
 from jupyter_util import echom, unquote_string, match_kernel_id, get_vim
-
 try:
     from queue import Queue, Empty
 except ImportError:
     from Queue import Queue, Empty
-
-# Local
 from language import list_languages
+
+# Process local
+import vim
 
 
 class VimMessenger():

--- a/pythonx/message_parser.py
+++ b/pythonx/message_parser.py
@@ -186,6 +186,7 @@ class JupyterMessenger():
         # The json may be badly encoding especially if autoconnecting
         try:
             kernel_manager.load_connection_file()
+        # pylint: disable=broad-except
         except Exception:
             return False
         self.km_client = kernel_manager.client()
@@ -477,10 +478,10 @@ def parse_iopub_for_reply(msgs, line_number):
         if not content:
             continue
 
-        ec = int(content.get('execution_count', 0))
-        if not ec:
+        i_count = int(content.get('execution_count', 0))
+        if not i_count:
             continue
-        if line_number not in (-1, ec):
+        if line_number not in (-1, i_count):
             continue
 
         msg_type = msg.get('header', {}).get('msg_type', '')

--- a/pythonx/monitor_console.py
+++ b/pythonx/monitor_console.py
@@ -19,7 +19,7 @@ except ImportError:
 class Monitor():
     """Jupyter kernel monitor buffer and message line"""
     def __init__(self, session_info):
-        self.si = session_info
+        self.session_info = session_info
         self.cmd = None
         self.cmd_id = None
         self.cmd_count = 0
@@ -28,16 +28,16 @@ class Monitor():
         """Decorator to monitor messages"""
         def wrapper(*args, **kwargs):
             # Check in
-            if not self.si.kernel_client.check_connection_or_warn():
+            if not self.session_info.kernel_client.check_connection_or_warn():
                 return
 
             # Call
             fct(*args, **kwargs)
 
             # Clause
-            self.si.vim_client.set_monitor_bools()
-            if (not self.si.vim_client.verbose
-                    and not self.si.vim_client.monitor_console):
+            self.session_info.vim_client.set_monitor_bools()
+            if (not self.session_info.vim_client.verbose
+                    and not self.session_info.vim_client.monitor_console):
                 return
 
             # Launch update threads
@@ -56,13 +56,13 @@ class Monitor():
             return
 
         # Define time: thread (additive) sleep and timer wait
-        timer_intervals = self.si.vim_client.get_timer_intervals()
+        timer_intervals = self.session_info.vim_client.get_timer_intervals()
         thread_intervals = [50]
         for i in range(len(timer_intervals)-1):
             thread_intervals.append(timer_intervals[i+1] - timer_intervals[i] - 50)
 
         # Create thread
-        self.si.sync.start_thread(
+        self.session_info.sync.start_thread(
             target=self.thread_fetch_msgs,
             args=[thread_intervals])
 
@@ -78,60 +78,64 @@ class Monitor():
         io_cache = list()
         for sleep_ms in intervals:
             # Sleep ms
-            if self.si.sync.check_stop():
+            if self.session_info.sync.check_stop():
                 return
             sleep(sleep_ms / 1000)
-            if self.si.sync.check_stop():
+            if self.session_info.sync.check_stop():
                 return
 
             # Get messages
-            msgs = self.si.kernel_client.get_pending_msgs()
-            io_new = parse_messages(self.si, msgs)
+            msgs = self.session_info.kernel_client.get_pending_msgs()
+            io_new = parse_messages(self.session_info, msgs)
 
             # Insert code line Check not already here (check with substr 'Py [')
             if (self.cmd is not None
                     and len(io_new) != 0
-                    and not any(self.si.lang.prompt_in[:4] in msg
+                    and not any(self.session_info.lang.prompt_in[:4] in msg
                                 for msg in io_new + io_cache)):
                 # Get cmd number from id
                 try:
-                    reply = self.si.kernel_client.get_reply_msg(self.cmd_id)
+                    reply = self.session_info.kernel_client.get_reply_msg(self.cmd_id)
                     line_number = reply['content'].get('execution_count', 0)
                 except (Empty, KeyError, TypeError):
                     line_number = -1
-                s = prettify_execute_intput(line_number, self.cmd, self.si.lang.prompt_in)
-                io_new.insert(0, s)
+                s_new_input = prettify_execute_intput(
+                        line_number, self.cmd, self.session_info.lang.prompt_in)
+                io_new.insert(0, s_new_input)
 
             # Append just new
-            _ = [self.si.sync.line_queue.put(s) for s in io_new if s not in io_cache]
+            _ = [self.session_info.sync.line_queue.put(s_in)
+                    for s_in in io_new
+                    if s_in not in io_cache]
             # Update cache
             io_cache = list(set().union(io_cache, io_new))
 
     def timer_write_console_msgs(self):
         """Write kernel <-> vim messages to console buffer"""
         # Check in
-        if self.si.sync.line_queue.empty():
+        if self.session_info.sync.line_queue.empty():
             return
-        if not self.si.vim_client.monitor_console and not self.si.vim_client.verbose:
+        if (not self.session_info.vim_client.monitor_console
+                and not self.session_info.vim_client.verbose):
             return
 
         # Get buffer (same indexes as vim)
-        if self.si.vim_client.monitor_console:
+        if self.session_info.vim_client.monitor_console:
             b_nb = int(vim.eval('bufnr("__jupyter_term__")'))
-            b = vim.buffers[b_nb]
+            buf = vim.buffers[b_nb]
 
         # Append mesage to jupyter terminal buffer
-        while not self.si.sync.line_queue.empty():
-            msg = self.si.sync.line_queue.get_nowait()
+        while not self.session_info.sync.line_queue.empty():
+            msg = self.session_info.sync.line_queue.get_nowait()
             for line in msg.splitlines():
                 line = unquote_string(str_to_vim(line))
-                if self.si.vim_client.monitor_console:
-                    b.append(line)
-                if self.si.vim_client.verbose:
+                if self.session_info.vim_client.monitor_console:
+                    buf.append(line)
+                if self.session_info.vim_client.verbose:
                     echom(line)
 
         # Update view (moving cursor)
-        if self.si.vim_client.monitor_console:
+        if self.session_info.vim_client.monitor_console:
             cur_win = vim.eval('win_getid()')
             term_win = vim.eval('bufwinid({})'.format(str(b_nb)))
             vim.command('call win_gotoid({})'.format(term_win))
@@ -160,7 +164,7 @@ def parse_messages(session_info, msgs):
     # TODO remove complexity
     res = list()
     for msg in msgs:
-        s = ''
+        s_line = ''
         default_count = session_info.monitor.cmd_count
         if 'msg_type' not in msg['header']:
             continue
@@ -181,20 +185,20 @@ def parse_messages(session_info, msgs):
             else:
                 prompt = 'Out[{:d}]: '.format(line_number)
                 dots = (' ' * (len(prompt.rstrip()) - 4)) + '...< '
-            s = prompt
+            s_line = prompt
             # Add continuation line, if necessary
-            s += text.rstrip().replace('\n', '\n' + dots)
+            s_line += text.rstrip().replace('\n', '\n' + dots)
             # Set cmd_count: if it changed
             if line_number != default_count:
                 session_info.monitor.cmd_count = line_number
 
         elif msg_type == 'display_data':
-            s += msg['content']['data']['text/plain']
+            s_line += msg['content']['data']['text/plain']
 
         elif msg_type in ('execute_input', 'pyin'):
             line_number = msg['content'].get('execution_count', default_count)
             cmd = msg['content']['code']
-            s = prettify_execute_intput(line_number, cmd, session_info.lang.prompt_in)
+            s_line = prettify_execute_intput(line_number, cmd, session_info.lang.prompt_in)
             # Set cmd_count: if it changed
             if line_number != default_count:
                 session_info.monitor.cmd_count = line_number
@@ -202,14 +206,14 @@ def parse_messages(session_info, msgs):
         elif msg_type in ('execute_result', 'pyout'):
             # Get the output
             line_number = msg['content'].get('execution_count', default_count)
-            s = session_info.lang.prompt_out.format(line_number)
-            s += msg['content']['data']['text/plain']
+            s_line = session_info.lang.prompt_out.format(line_number)
+            s_line += msg['content']['data']['text/plain']
             # Set cmd_count: if it changed
             if line_number != default_count:
                 session_info.monitor.cmd_count = line_number
 
         elif msg_type in ('error', 'pyerr'):
-            s = "\n".join((strip_color_escapes(x) for x in msg['content']['traceback']))
+            s_line = "\n".join((strip_color_escapes(x) for x in msg['content']['traceback']))
 
         elif msg_type == 'input_request':
             session_info.vim_client.thread_echom(
@@ -221,6 +225,6 @@ def parse_messages(session_info, msgs):
             continue
 
         # List all messages
-        res.append(s)
+        res.append(s_line)
 
     return res

--- a/pythonx/monitor_console.py
+++ b/pythonx/monitor_console.py
@@ -4,16 +4,17 @@ Feature to get a buffer with jupyter output
 
 # Standard
 from time import sleep
-import vim
 
 # Local
 from jupyter_util import echom, prettify_execute_intput, str_to_vim, \
                          strip_color_escapes, unquote_string
-
 try:
     from queue import Empty
 except ImportError:
     from Queue import Empty
+
+# Process local
+import vim
 
 
 class Monitor():

--- a/test/02_command.vader
+++ b/test/02_command.vader
@@ -23,6 +23,7 @@ Execute (JupyterConnect):
 # :JupyterCd [dir]
 Execute (JupyterCd):
   JupyterCd
+
 # :JupyterRunFile [flags] [filename]
 Execute (JupyterRunFile):
   JupyterRunFile %

--- a/test/03_variable.vader
+++ b/test/03_variable.vader
@@ -1,0 +1,60 @@
+# Jupyter variable
+# See #60
+
+# Begin Basic
+Given python (Python):
+  print('init-1')         # 1
+  print('init-2')         # 2
+  ## Cell default         # 3
+  print('default')        # 4
+  print('1')              # 5
+  print('2')              # 6
+  ## End of cell          # 7
+
+  # Far is titi           # 9
+  print('t_i_t_i')        # 10
+  print('1')              # 11
+  print('2')              # 12
+  # End of titi           # 13
+  
+  print('In the middle')  # 15
+  
+  #toto                   # 17
+  print('toto')           # 18
+  #toto                   # 19
+  print('toto-end')       # 20
+  ## Not afecting toto    # 21
+  print('toto-1')         # 22
+  print('toto-2')         # 23
+
+# Configure
+Execute (Configure and play):
+  let g:jupyter_cell_separators = ['##', '#toto', '.*titi']
+
+## Spawn kernel
+Execute (Spawn jupyter):
+  Log "Spawn Jupyter kernel"
+  call system("jupyter-kernel &")
+
+# :JupyterConnect [connection_file]
+Execute (JupyterConnect):
+  JupyterConnect
+
+Execute (SendCells):
+  call cursor(1,1) | JupyterSendCell " init-1\ninit-2
+  call cursor(4,1) | JupyterSendCell " default
+  call cursor(8,1) | JupyterSendCell " <void>
+  call cursor(10,1) | JupyterSendCell " t_i_t_i
+  call cursor(15,1) | JupyterSendCell " in the middle
+  call cursor(18,1) | JupyterSendCell " toto
+  call cursor(20,1) | JupyterSendCell " toto-end ...
+
+##:JupyterDisconnect
+Execute (JupyterDisconnect):
+  JupyterDisconnect
+Execute (JupyterConnect -> Reconnect):
+  JupyterConnect
+
+#:JupyterTerminateKernel
+Execute (JupyterTerminateKernel):
+  silent JupyterTerminateKernel

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,21 @@
+Tests must be made with docker command in jupyter-vim root directory
+
+jupyter-vim <- testbed/vim:latest <- alpine:3.12: A minimal Docker image based on Alpine Linux with a complete package index and only 5 MB in size!
+
+```bash
+# Build image
+docker build --tag  jupyter-vim .
+
+# Run tests
+docker run -it --rm -v $PWD/:/testplugin jupyter-vim /vim-build/bin/vim_8.1.0519 -i NONE -N -u /testplugin/test/vimrc -Es '+Vader! /testplugin/test/*.vader'
+```
+
+* -v Bind volume: repodir -> /testing
+* -i No viminfo
+* -N No compatible
+* -u  Vimrc
+* -Es Execute mode, non interactive
+
+The docker image aims to provide:
+1. Vim with python3 support
+2. Jupyter (with libzmq well installed)

--- a/test/README.md
+++ b/test/README.md
@@ -2,6 +2,7 @@ Tests must be made with docker command in jupyter-vim root directory
 
 jupyter-vim <- testbed/vim:latest <- alpine:3.12: A minimal Docker image based on Alpine Linux with a complete package index and only 5 MB in size!
 
+
 ```bash
 # Build image
 docker build --tag  jupyter-vim .
@@ -19,3 +20,6 @@ docker run -it --rm -v $PWD/:/testplugin jupyter-vim /vim-build/bin/vim_8.1.0519
 The docker image aims to provide:
 1. Vim with python3 support
 2. Jupyter (with libzmq well installed)
+
+
+More in .travis.yml

--- a/test/README.md
+++ b/test/README.md
@@ -22,4 +22,11 @@ The docker image aims to provide:
 2. Jupyter (with libzmq well installed)
 
 
+## Pylint
+
+Ignoring:
+* W0511: if "TODO" in code
+* E0401: cannot import vim (because must be in vim and not in pylint)
+
+
 More in .travis.yml

--- a/test/vimrc
+++ b/test/vimrc
@@ -6,10 +6,6 @@ set rtp+=after
 filetype plugin indent on
 syntax enable
 
-" Tin special hack (vim compiled for 3.8)
-" TODO get .travis work
-set pythonthreedll=/usr/lib/python3.9/config-3.9-x86_64-linux-gnu/libpython3.9.so
-
 " Import package to test
 packadd vader
 packadd jupyter

--- a/test/vimrc
+++ b/test/vimrc
@@ -1,14 +1,8 @@
-" Standard noncompatible
-set nocompatible
-set rtp+=vader.vim
-set rtp+=.
-set rtp+=after
+" Import package to test
+set runtimepath+=/vader
+set runtimepath+=/testplugin
 filetype plugin indent on
 syntax enable
-
-" Import package to test
-packadd vader
-packadd jupyter
 
 " Reset variable
 for [s:key, s:val] in items(g:jupyter_default_settings)

--- a/test/vimrc
+++ b/test/vimrc
@@ -4,8 +4,9 @@ set runtimepath+=/testplugin
 filetype plugin indent on
 syntax enable
 
-" Reset variable
-for [s:key, s:val] in items(g:jupyter_default_settings)
-    let value = s:val
-    execute 'let g:jupyter_' . s:key . ' = value'
-endfor
+function VaderResetVariable()
+  for [s:key, s:val] in items(g:jupyter_default_settings)
+      let value = s:val
+      execute 'let g:jupyter_' . s:key . ' = value'
+  endfor
+endfunction

--- a/test/vimrc
+++ b/test/vimrc
@@ -1,0 +1,21 @@
+" Standard noncompatible
+set nocompatible
+set rtp+=vader.vim
+set rtp+=.
+set rtp+=after
+filetype plugin indent on
+syntax enable
+
+" Tin special hack (vim compiled for 3.8)
+" TODO get .travis work
+set pythonthreedll=/usr/lib/python3.9/config-3.9-x86_64-linux-gnu/libpython3.9.so
+
+" Import package to test
+packadd vader
+packadd jupyter
+
+" Reset variable
+for [s:key, s:val] in items(g:jupyter_default_settings)
+    let value = s:val
+    execute 'let g:jupyter_' . s:key . ' = value'
+endfor


### PR DESCRIPTION
As reported in #60 the `g:jupyter_cell_separators` was not well working.
I think this is mostly due to the fact that the default configuration dictionary had all its values as string (and not list).

This commit fix it, see tests.
Can be verified with

```bash
cd ~/.vim/pack/opt/jupyter  # or wherever your jupyter package is installed 
git fetch origin pull/65/head:pr_65   # origin is the remote, suposing git remote -v  ->  origin https://github.com/jupyter-vim/jupyter-vim (fetch)    
git checkout pr_65
```