### PR TITLE
Fix command with complete but no nargs

### DIFF
--- a/ftplugin/python/jupyter.vim
+++ b/ftplugin/python/jupyter.vim
@@ -13,11 +13,11 @@ let b:ipython_run_flags = ''
 "}}}--------------------------------------------------------------------------
 "        Commands: {{{
 "-----------------------------------------------------------------------------
-command! -buffer -nargs=0 -complete=file
+command! -buffer -nargs=? -complete=file
             \ PythonImportThisFile update | call jupyter#RunFile('-n', expand("%:p"))
 
 " Debugging commands
-command! -nargs=0   PythonSetBreak  call jupyter#PythonDbstop()
+command! -nargs=?   PythonSetBreak  call jupyter#PythonDbstop()
 
 "}}}--------------------------------------------------------------------------
 "        Key Mappings: {{{


### PR DESCRIPTION
The argument for nargs must be "?" for this not to generate the following error upon start:

_"Error detected while processing BufRead Autocommands for ".py"..FileType Autocommands for ""..function 15_LoadFTPlugin[17]..script /Users/cc/.vim/bundle/jupyter-vim/ftplugin/python/jupyter.vim:
line 16: E1208: -complete used without allowing arguments
Press ENTER or type command to continue"_