### PR TITLE
Add jupyter cell highlighting in python files

### DIFF
--- a/doc/jupyter-vim.txt
+++ b/doc/jupyter-vim.txt
@@ -260,6 +260,13 @@ string.
 The match starts at the beginning of line: hence the `.*` in the previous
 example
 
+`g:jupyter_highlight_cells`        		*g:jupyter_highlight_cells
+				  Boolean to toggle cell highlighting 
+Default: 1
+
+This option will use syntax highlighting in order to highlight the cells
+defined by g:jupyter_cell_separators if set to true. 
+
 `g:jupyter_mapkeys`   					*g:jupyter_mapkeys*
 Default: 1 					Map keys for python files
 

--- a/ftplugin/python/jupyter.vim
+++ b/ftplugin/python/jupyter.vim
@@ -10,6 +10,14 @@
 " User-specified flags for IPython's run file magic can be set per-buffer
 let b:ipython_run_flags = ''
 
+" Highlight jupyter cells (lines beginning with ##) such that it is easier to
+" see them
+fun! SetCellHighlighting()
+    syn match jupyterCell  "^##\([^#]\|$\).*$"
+    highlight jupyterCell  ctermfg=255 guifg=#eeeeee ctermbg=022 guibg=#005f00 cterm=bold gui=bold
+endfu
+autocmd bufenter * :call SetCellHighlighting()
+
 "}}}--------------------------------------------------------------------------
 "        Commands: {{{
 "-----------------------------------------------------------------------------

--- a/ftplugin/python/jupyter.vim
+++ b/ftplugin/python/jupyter.vim
@@ -12,11 +12,18 @@ let b:ipython_run_flags = ''
 
 " Highlight jupyter cells (lines beginning with ##) such that it is easier to
 " see them
-fun! SetCellHighlighting()
-    syn match jupyterCell  "^##\([^#]\|$\).*$"
-    highlight jupyterCell  ctermfg=255 guifg=#eeeeee ctermbg=022 guibg=#005f00 cterm=bold gui=bold
-endfu
-autocmd bufenter * :call SetCellHighlighting()
+if g:jupyter_highlight_cells
+    fun! SetCellHighlighting()
+        for cell_separator in g:jupyter_cell_separators
+            let regex_cell= "^" . cell_separator . "\\([^#]\\|$\\).*$"
+            let match_cmd = "syntax match JupyterCell \"" . regex_cell . "\"" 
+            let highlight_cmd = "highlight JupyterCell ctermfg=255 guifg=#eeeeee ctermbg=022 guibg=#005f00 cterm=bold gui=bold"
+            execute match_cmd
+            execute highlight_cmd
+        endfor
+    endfu
+    autocmd bufenter * :call SetCellHighlighting()
+endif
 
 "}}}--------------------------------------------------------------------------
 "        Commands: {{{

--- a/plugin/jupyter.vim
+++ b/plugin/jupyter.vim
@@ -23,7 +23,6 @@ let g:jupyter_default_settings = {
     \ 'timer_interval': 500,
     \ 'verbose': 0
 \ }
-echom g:jupyter_default_settings
 
 for [s:key, s:val] in items(g:jupyter_default_settings)
     if !exists('g:jupyter_' . s:key)

--- a/plugin/jupyter.vim
+++ b/plugin/jupyter.vim
@@ -18,10 +18,12 @@ endif
 let g:jupyter_default_settings = {
     \ 'auto_connect': 0,
     \ 'cell_separators': ['##', '#%%', '# %%', '# <codecell>'],
+    \ 'highlight_cells': 1, 
     \ 'mapkeys': 1,
     \ 'timer_interval': 500,
     \ 'verbose': 0
 \ }
+echom g:jupyter_default_settings
 
 for [s:key, s:val] in items(g:jupyter_default_settings)
     if !exists('g:jupyter_' . s:key)


### PR DESCRIPTION
Hi, 

I thought it may be a good idea to add highlighting for jupyter cells such that it is easier to see them when executing code. 
What do you think about it? 
I basically stole this from the vim-matlab plugin. 
