### PR TITLE
Do not override highlight group if already set

### DIFF
--- a/ftplugin/python/jupyter.vim
+++ b/ftplugin/python/jupyter.vim
@@ -18,8 +18,10 @@ if g:jupyter_highlight_cells
             let regex_cell= "^" . cell_separator . "\\([^#]\\|$\\).*$"
             let match_cmd = "syntax match JupyterCell \"" . regex_cell . "\"" 
             let highlight_cmd = "highlight JupyterCell ctermfg=255 guifg=#eeeeee ctermbg=022 guibg=#005f00 cterm=bold gui=bold"
+            if !hlexists('JupyterCell')
+                execute highlight_cmd
+            endif
             execute match_cmd
-            execute highlight_cmd
         endfor
     endfu
     autocmd bufenter * :call SetCellHighlighting()


### PR DESCRIPTION
Right now, the `JupyterCell` highlight group is reset every time a buffer is opened. This means it can not be overridden in user settings. This PR adds some simple logic to check if an highlight rule already exists (e.g. the user added it in .vimrc) before setting it. 

Though I'm new to vim scripting, this is a very simple and small change, and it works for me.