### PR TITLE
Fix error event loop error message on windows

### DIFF
--- a/python3/jupyter_messenger.py
+++ b/python3/jupyter_messenger.py
@@ -10,6 +10,7 @@ import collections
 from textwrap import dedent
 from threading import Thread
 from queue import Queue, Empty
+import sys
 
 # Py module
 from jupyter_client import AsyncKernelManager, find_connection_file
@@ -42,6 +43,8 @@ class JupyterMessenger():
     def __init__(self):
         self.km_client = None      # KernelManager client
         self.background_thread = None
+        if sys.platform == 'win32':
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
         self.loop = asyncio.new_event_loop()
         self.kernel_info = dict()  # Kernel information
         self.lang = get_language('')


### PR DESCRIPTION
On windows, `asyncio` is complaining:

```
RuntimeWarning: Proactor event loop does not implement add_reader family of methods required for zmq [...] Use asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolity()) to avoid this warning.
```

This PR implements the suggestion in the message and it seems to work fine.