### PR TITLE
Add a default for g:jupyter_highlight_cells

### DIFF
--- a/ftplugin/python/jupyter.vim
+++ b/ftplugin/python/jupyter.vim
@@ -12,6 +12,9 @@ let b:ipython_run_flags = ''
 
 " Highlight jupyter cells (lines beginning with ##) such that it is easier to
 " see them
+if !exists("g:jupyter_highlight_cells")
+    let g:jupyter_highlight_cells=1
+endif
 if g:jupyter_highlight_cells
     fun! SetCellHighlighting()
         for cell_separator in g:jupyter_cell_separators


### PR DESCRIPTION
This variable is used in the code, but does not have a default value set. This will break the plugin if the user hasn't defined this in their `vimrc`.