### PR TITLE
Make BufEnter cell highlighting autocommand buffer-local

### DIFF
--- a/ftplugin/python/jupyter.vim
+++ b/ftplugin/python/jupyter.vim
@@ -24,7 +24,10 @@ if g:jupyter_highlight_cells
             execute match_cmd
         endfor
     endfu
-    autocmd bufenter * :call SetCellHighlighting()
+    exe 'augroup jupyter_highlight_cell_' . bufnr()
+    exe '  au!'
+    exe '  autocmd BufEnter <buffer> call SetCellHighlighting()'
+    exe 'augroup END'
 endif
 
 "}}}--------------------------------------------------------------------------


### PR DESCRIPTION
Currently this plugin contains a naked `BufEnter` command that applies a jupyter cell-highlighting syntax override. Since the autocommand is not in an `augroup`, it can get duplicated across large vim sessions, and since it runs even on non-python files and involves changing the syntax, this can cause pretty huge slowdowns.

This PR both 1) puts the autocommand in an `augroup` and 2) makes the event local to each python buffer. 